### PR TITLE
15240 Text Behind Default Modal Showing through Default Modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2694,8 +2694,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2713,13 +2712,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2732,18 +2729,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2846,8 +2840,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2857,7 +2850,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2870,20 +2862,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2900,7 +2889,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2973,8 +2961,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2984,7 +2971,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3060,8 +3046,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3091,7 +3076,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3109,7 +3093,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3148,13 +3131,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6857,13 +6838,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6880,8 +6859,7 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",

--- a/src/pages/ModalPage.js
+++ b/src/pages/ModalPage.js
@@ -64,8 +64,8 @@ const mainContent = () => (
     <Section>
       <h3>Default Modal</h3>
       <p>Modal can close by button or clicking outside of the modal.</p>
-      <DemoModal id="default-modal" isDismissible="true" />
     </Section>
+    <DemoModal id="default-modal" isDismissible="true" />
     <Section>
       <h3>Modal must use a button to close.</h3>
       <p>
@@ -73,8 +73,8 @@ const mainContent = () => (
         modal. A good case for this usage is a form that you don't want the user
         to lose data.
       </p>
-      <DemoModal id="default-modal-not-dismissible" isDismissible="false" />
     </Section>
+    <DemoModal id="default-modal-not-dismissible" isDismissible="false" />
   </React.Fragment>
 );
 


### PR DESCRIPTION
References bug [15240](https://oittfs.bcg.ad.bcgov.us/BAUCollection/BaltimoreCounty.Gov%20Website/_workitems/edit/15240) Opening PR for the fix of this instance. May need to revise how sections are setup in another bug (and therefore PR) as this is something that will probably surface again. The source of the issue appears to stem from the z-index setup of `.dg_section .dg_section__content`. Here, the z-index is set to 999. This means, that while the z-index of the modal popup container is set at a high number and will work for elements above and inside its parent container, it cannot exceed 999 for elements outside of its parent element that appear below it. For this fix, will need to look through what elements have a z-index associated with them and subsequently revise some additional elements.